### PR TITLE
Make the spare Admin in prod set via ENV

### DIFF
--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -7,7 +7,7 @@ from rest_framework.documentation import include_docs_urls
 from core.views import AppView
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    url(settings.ADMIN_URL, admin.site.urls),
 
     # API endpoints
     url(r'^api/', include('api.urls')),

--- a/server/spare/settings/base.py
+++ b/server/spare/settings/base.py
@@ -120,6 +120,9 @@ REST_FRAMEWORK = {
     ),
 }
 
+# Location of root django.contrib.admin URL, use {% url 'admin:index' %}
+ADMIN_URL = r'^admin/'
+
 # Auth/Login Settings
 LOGIN_REDIRECT_URL = 'api-root'
 LOGIN_URL = 'login'

--- a/server/spare/settings/prod.py
+++ b/server/spare/settings/prod.py
@@ -1,4 +1,6 @@
 from .base import *  # noqa
+
+import os
 import dj_database_url
 
 DEBUG = False
@@ -14,3 +16,7 @@ DATABASES = {
 }
 
 MIDDLEWARE = ['whitenoise.middleware.WhiteNoiseMiddleware'] + MIDDLEWARE
+
+
+# Location of root django.contrib.admin URL, use {% url 'admin:index' %}
+ADMIN_URL = os.environ.get('ADMIN_URL','admin/')


### PR DESCRIPTION
#148 Make the Spare Admin url in prod set up via ENV

`/admin` is a standard and easy to guess. The admin url should be something a little less standard like `/spare_control_panel/` to make it less guess able