### PR TITLE
Add django-admin-rangefilter to requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,7 @@ django-debug-toolbar==1.8
 django-enumfields==0.10.1
 django-extensions==1.9.1
 django-filter==1.1.0
+django-admin-rangefilter==0.3.8
 django-model-utils==3.1.1
 django-phonenumber-field==2.0.0
 django-rq==1.1.0


### PR DESCRIPTION
When attempting to build the docker container in my local environment, I kept running into the error of the 'rangefilter' module not being found. Adding the latest stable release of the package to requirements.txt solved the issue.